### PR TITLE
Bump com.android.tools.build:gradle from 8.4.1 to 8.8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.4.1'
+        classpath 'com.android.tools.build:gradle:8.8.1'
     }
 }
 


### PR DESCRIPTION
Bumps com.android.tools.build:gradle from 8.4.1 to 8.8.1.

---
updated-dependencies:
- dependency-name: com.android.tools.build:gradle dependency-type: direct:production update-type: version-update:semver-minor ...